### PR TITLE
Release v1.2.4 - Promote all services

### DIFF
--- a/kustomize/overlays/dev/kustomization.yaml
+++ b/kustomize/overlays/dev/kustomization.yaml
@@ -38,34 +38,34 @@ commonAnnotations:
 images:
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/frontend
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/frontend
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/cartservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/cartservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/productcatalogservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/productcatalogservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/currencyservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/currencyservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/paymentservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/paymentservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/shippingservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/shippingservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/emailservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/emailservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/checkoutservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/checkoutservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/recommendationservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/recommendationservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/adservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/adservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 
 # Patches for dev environment
 patches:

--- a/kustomize/overlays/prod/kustomization.yaml
+++ b/kustomize/overlays/prod/kustomization.yaml
@@ -37,34 +37,34 @@ commonAnnotations:
 images:
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/frontend
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/frontend
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/cartservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/cartservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/productcatalogservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/productcatalogservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/currencyservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/currencyservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/paymentservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/paymentservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/shippingservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/shippingservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/emailservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/emailservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/checkoutservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/checkoutservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/recommendationservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/recommendationservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/adservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/adservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 
 # Replica patches for prod (higher replicas for HA)
 patches:

--- a/kustomize/overlays/qa/kustomization.yaml
+++ b/kustomize/overlays/qa/kustomization.yaml
@@ -34,37 +34,37 @@ commonAnnotations:
 images:
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/frontend
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/frontend
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/cartservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/cartservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/productcatalogservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/productcatalogservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/currencyservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/currencyservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/paymentservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/paymentservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/shippingservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/shippingservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/emailservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/emailservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/checkoutservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/checkoutservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/recommendationservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/recommendationservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/adservice
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/adservice
-  newTag: v1.2.3
+  newTag: v1.2.4
 - name: us-central1-docker.pkg.dev/google-samples/microservices-demo/loadgenerator
   newName: 533267307120.dkr.ecr.eu-west-2.amazonaws.com/loadgenerator
-  newTag: v1.2.3
+  newTag: v1.2.4
 
 # Replica patches for qa (moderate replicas)
 patches:


### PR DESCRIPTION
## Release v1.2.4

This PR promotes all microservices to version **v1.2.4** across all environments.

### Changes
- ✅ Updated image tags from `v1.2.3` to `v1.2.4` in all Kustomize overlays
- 📦 Dev environment: `microservices-dev` namespace
- 📦 QA environment: `microservices-qa` namespace  
- 📦 Prod environment: `microservices-prod` namespace

### Services Updated
All 10 microservices:
- frontend
- cartservice
- productcatalogservice
- currencyservice
- paymentservice
- shippingservice
- emailservice
- checkoutservice
- recommendationservice
- adservice

### Deployment Plan
1. Merge this PR to `main`
2. GitHub Actions will automatically:
   - Validate Kustomize manifests
   - Apply to dev environment first
   - Promote to QA after successful dev deployment
   - Promote to prod after QA validation

### Testing
- ✅ Kustomize manifests validated
- ✅ Image tags updated consistently across all environments
- ⏳ Awaiting automated deployment after merge

---
🤖 Generated via automated promotion workflow