### PR TITLE
Fix test results path mismatch - file vs directory detection

### DIFF
--- a/.github/workflows/run-unit-tests.yaml
+++ b/.github/workflows/run-unit-tests.yaml
@@ -229,6 +229,17 @@ jobs:
             echo "✅ Test results found: $TEST_FILE"
             echo "found=true" >> $GITHUB_OUTPUT
             echo "path=$TEST_FILE" >> $GITHUB_OUTPUT
+
+            # Detect if path is file or directory and set appropriate pattern
+            if [ -f "$TEST_FILE" ]; then
+              # File: Use the file path directly
+              echo "pattern=$TEST_FILE" >> $GITHUB_OUTPUT
+              echo "📄 Type: File - using path: $TEST_FILE"
+            else
+              # Directory: Append glob pattern to find XML files
+              echo "pattern=$TEST_FILE/**/*.xml" >> $GITHUB_OUTPUT
+              echo "📁 Type: Directory - using pattern: $TEST_FILE/**/*.xml"
+            fi
           fi
 
       # =====================================================================
@@ -254,7 +265,7 @@ jobs:
         if: always() && steps.find-results.outputs.found == 'true'
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          files: ${{ steps.find-results.outputs.path }}/**/*.xml
+          files: ${{ steps.find-results.outputs.pattern }}
           check_name: "${{ inputs.service }} Test Results"
         continue-on-error: true
 


### PR DESCRIPTION
## Summary

Fixes #63 - Test results publishing path mismatch causing empty test data in ServiceNow

## Problem

The workflow was blindly appending `/**/*.xml` to all test result paths, which broke for the **11 services** that create `test-results.xml` as a FILE (not directory). This caused:

- ❌ "Could not find any files" warnings in all 12 test jobs
- ❌ Empty test data sent to ServiceNow (0 tests reported)
- ❌ No test results published to GitHub PR checks
- ❌ DevOps Insights dashboard showing 0 tests for all services

### Error Example
```
WARNING - Could not find any files for src/paymentservice/test-results.xml/**/*.xml
```

**Invalid path**: `src/paymentservice/test-results.xml/**/*.xml` (can't append directory glob to file)

## Changes

### 1. Updated "Locate Test Results" Step
Added file vs directory detection logic that outputs appropriate glob pattern:

```yaml
# Detect if path is file or directory and set appropriate pattern
if [ -f "$TEST_FILE" ]; then
  # File: Use the file path directly
  echo "pattern=$TEST_FILE" >> $GITHUB_OUTPUT
else
  # Directory: Append glob pattern to find XML files
  echo "pattern=$TEST_FILE/**/*.xml" >> $GITHUB_OUTPUT
fi
```

### 2. Updated "Publish Test Results" Step
Changed from hardcoded pattern to smart pattern output:

```yaml
# Before (broken):
files: ${{ steps.find-results.outputs.path }}/**/*.xml

# After (fixed):
files: ${{ steps.find-results.outputs.pattern }}
```

## Impact

### Services with Real Tests (Will Now Publish Results)
- ✅ **frontend**: 2 Go test files
- ✅ **checkoutservice**: 1 Go test file
- ✅ **productcatalogservice**: 1 Go test file
- ✅ **shippingservice**: 1 Go test file

### Services with Placeholders (Correctly Show 0)
- 📝 currencyservice, paymentservice, emailservice, recommendationservice, shoppingassistantservice, adservice, cartservice, loadgenerator

## Testing

This PR will trigger test workflows automatically. Expected results:

- ✅ No "Could not find any files" warnings in any test job
- ✅ Go services publish actual test results (count > 0)
- ✅ Test results appear in GitHub PR checks
- ✅ ServiceNow receives accurate test data
- ✅ DevOps Insights dashboard shows correct metrics

## Verification Commands

After merge and workflow run:

```bash
# Check for warnings in logs (should be empty)
gh run view <run-id> --log | grep "Could not find any files"

# Verify ServiceNow test results
curl -s -u "$SERVICENOW_USERNAME:$SERVICENOW_PASSWORD" \
  "https://calitiiltddemo3.service-now.com/api/now/table/sn_devops_test_result?sysparm_query=pipeline_id=<RUN_ID>" \
  | jq '.result[] | {test_name, passed, failed, total}'
```

## Files Changed

- `.github/workflows/run-unit-tests.yaml` (12 lines added)

## Related Issues

- #60: ServiceNow package linking HTTP 403 error (FIXED)
- #62: Missing application data in ServiceNow Insights

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>